### PR TITLE
busybox: Disable build with Clang for now

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -211,4 +211,5 @@ LOCAL_UNSTRIPPED_PATH := $(PRODUCT_OUT)/symbols/utilities
 $(LOCAL_MODULE): busybox_prepare
 LOCAL_PACK_MODULE_RELOCATIONS := false
 LOCAL_ADDITIONAL_DEPENDENCIES := $(busybox_prepare_full)
+LOCAL_CLANG := false
 include $(BUILD_EXECUTABLE)

--- a/Android.mk
+++ b/Android.mk
@@ -160,6 +160,7 @@ LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
 LOCAL_SHARED_LIBRARIES := libc libcutils libm
 LOCAL_STATIC_LIBRARIES := libclearsilverregex libuclibcrpc libselinux
 LOCAL_ADDITIONAL_DEPENDENCIES := $(busybox_prepare_full)
+LOCAL_CLANG := false
 include $(BUILD_EXECUTABLE)
 
 BUSYBOX_LINKS := $(shell cat $(BB_PATH)/busybox-$(BUSYBOX_CONFIG).links)


### PR DESCRIPTION
When build with:

USE_CLANG_PLATFORM_BUILD := true

get this error on lines that have ("vfork"+1)

error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]

Commit from CM tree.

I only test CLANG to build a recovery this was the only error I found.
